### PR TITLE
Remove File Size Limit for local uploads

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,7 @@
 
 ## API & Data Flow
 - User selects stems and uploads file or YouTube URL via frontend.
-- Frontend JS validates file type/size (max 100MB, MP3/WAV/FLAC/M4A/AAC) and YouTube URL (max 10 min, public).
+- Frontend JS validates file type (MP3/WAV/FLAC/M4A/AAC) and YouTube URL (max 10 min, public). No file size limit for uploads (local use).
 - `/api/separate` (file) and `/api/separate-youtube` (YouTube) endpoints process requests, call separation logic, and return download links for each stem.
 - Results are displayed dynamically; download links use stem icons/names from backend config.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can now choose between different AI models for separation:
 ## 📋 Supported formats
 
 ✅ **MP3**, WAV, FLAC, M4A, AAC  
-📏 **Limit:** 100MB per file  
+📏 **Limit:** No file size limit (local use)
 ⏱️ **YouTube:** Maximum 10 minutes
 
 ## 🛠️ Technical details

--- a/README.md
+++ b/README.md
@@ -67,6 +67,39 @@ python main.py
 
 Access [http://localhost:7860](http://localhost:7860).
 
+---
+
+## 🔒 Local HTTPS & Browser Security Warnings
+
+By default, the app runs on plain HTTP for simplicity. Modern browsers may show warnings like "Not Secure" or block downloads when using HTTP, even for local apps. This is normal and safe for local use.
+
+**To avoid these warnings:**
+
+1. **Use HTTPS locally with a self-signed certificate:**
+   - Generate a certificate (one-time):
+     ```bash
+     openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj "/CN=localhost"
+     ```
+   - Run the app with HTTPS:
+     ```bash
+     uvicorn main:app --host 0.0.0.0 --port 7860 --reload --ssl-keyfile=key.pem --ssl-certfile=cert.pem
+     ```
+   - Access the app at [https://localhost:7860](https://localhost:7860) and accept the browser warning about the self-signed certificate.
+
+2. **You may commit and reuse the same `.pem` files for local development.**
+   - This is safe for local-only use. Never use these files in production.
+   - All users will see a browser warning the first time, unless they add the certificate to their trusted store (not required for local dev).
+
+3. **If you use plain HTTP:**
+   - You may see "Not Secure" warnings and Chrome may block downloads. You can safely click "Keep" or "Download anyway" for your own files.
+
+**Summary:**
+- For local use, these warnings are not a risk.
+- For the best user experience, use HTTPS as above.
+- Always access the app at [http://localhost:7860](http://localhost:7860) or [https://localhost:7860](https://localhost:7860), not `0.0.0.0`.
+
+Access [http://localhost:7860](http://localhost:7860).
+
 ## 🎵 Usage
 ### Model Selection Feature
 

--- a/README_PT-BR.md
+++ b/README_PT-BR.md
@@ -134,7 +134,7 @@ docker cp voice-separator:/app/static/output ./meus-arquivos/
 - **M4A** - iTunes/Apple
 - **AAC** - Comprimido
 
-**Tamanho máximo:** 100MB por arquivo
+**Tamanho máximo:** Sem limite de tamanho de arquivo (uso local)
 
 ## 🔧 Solução de problemas
 

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -110,13 +110,6 @@ async def separate_audio(
                     detail=f"Unsupported file format. Use: {', '.join(ALLOWED_EXTENSIONS)}"
                 )
         
-        # Check file size (100MB limit)
-        if hasattr(file, 'size') and file.size > 100 * 1024 * 1024:
-            raise HTTPException(
-                status_code=400,
-                detail="File too large. Maximum limit: 100MB"
-            )
-        
         # Process stems list
         selected_stems = [stem.strip() for stem in stems.split(",") if stem.strip()]
         if not selected_stems:
@@ -338,4 +331,11 @@ async def health_check():
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run("main:app", host="0.0.0.0", port=7860, reload=True)
+    uvicorn.run(
+        "main:app",
+        host="0.0.0.0",
+        port=7860,
+        reload=True,
+        timeout_keep_alive=1200,  # 20 minutes
+        timeout_graceful_shutdown=1200,  # 20 minutes
+    )

--- a/templates/index.html
+++ b/templates/index.html
@@ -474,7 +474,6 @@
                     return;
                 }
                 
-                
                 showStatus('Valid file selected. Click "Separate Vocals" to continue.', 'info');
             } else {
                 fileInfo.style.display = 'none';

--- a/templates/index.html
+++ b/templates/index.html
@@ -474,12 +474,6 @@
                     return;
                 }
                 
-                // Check size (100MB)
-                if (file.size > 100 * 1024 * 1024) {
-                    showStatus('File too large. Maximum limit: 100MB', 'error');
-                    separateBtn.disabled = true;
-                    return;
-                }
                 
                 showStatus('Valid file selected. Click "Separate Vocals" to continue.', 'info');
             } else {


### PR DESCRIPTION
This pull request removes the 100MB file size limit for local uploads and introduces extended timeout settings for server operations. The changes impact documentation, API logic, and server configuration.

### Removal of File Size Limit for Local Uploads:
* [`.github/copilot-instructions.md`](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L28-R28): Updated frontend validation to remove the file size limit for uploads.
* `README.md` and `README_PT-BR.md`: Revised documentation to reflect the removal of the 100MB file size limit for local use. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L111-R111) [[2]](diffhunk://#diff-57c1f5957439a615ecef79b3970a6526e6e920b4d2dc5f0e055407a36e0e5d54L137-R137)
* [`src/api/routes.py`](diffhunk://#diff-2b14c7a998aaa1ab1d7edf7c92ea3a82f9739c3e2d0ee69fd33b2aa0e71f68beL113-L119): Removed backend logic that enforced the 100MB file size limit during file upload validation.
* [`templates/index.html`](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2L477-L482): Removed frontend checks for the 100MB file size limit in the file upload process.

### Extended Timeout Settings for Server Operations:
* [`src/api/routes.py`](diffhunk://#diff-2b14c7a998aaa1ab1d7edf7c92ea3a82f9739c3e2d0ee69fd33b2aa0e71f68beL341-R341): Added `timeout_keep_alive` and `timeout_graceful_shutdown` parameters to the `uvicorn.run` configuration, setting both to 20 minutes for extended server operation timeouts.

### Fixes

- #2 